### PR TITLE
fix: prevent negative amounts in transfer endpoint

### DIFF
--- a/app/api/bank_routes.py
+++ b/app/api/bank_routes.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends
 
 from app.api.dependencies import get_transfer_service
 from app.services.bank_service import TransferService
+from app.validator.amount_validator import validate_positive_amount
 
 router = APIRouter()
 
@@ -15,6 +16,10 @@ def transfer_money_online(from_account_id: int, to_account_id: int, amount: int,
     Transfer money online between two accounts
     """
     try:
+        # Validate that amount is positive
+        validation_result = validate_positive_amount(amount)
+        validation_result.raise_if_error()
+        
         transfer_service.transfer_money(from_account_id, to_account_id, amount)
         return {"message": "Transfer successful"}
     except ValueError as e:

--- a/app/validator/amount_validator.py
+++ b/app/validator/amount_validator.py
@@ -47,3 +47,9 @@ def validate_maximum_cash_amount(amount: int) -> ValidationResult:
     if amount > 10000:
         return ValidationResult.error("Amount cannot exceed 10000.")
     return ValidationResult.success()
+
+
+def validate_positive_amount(amount: int) -> ValidationResult:
+    if amount <= 0:
+        return ValidationResult.error("Amount must be positive.")
+    return ValidationResult.success()

--- a/app/validator/test_amount_validator.py
+++ b/app/validator/test_amount_validator.py
@@ -4,6 +4,7 @@ from app.validator.amount_validator import (
     ValidationError,
     ValidationResult,
     validate_maximum_cash_amount,
+    validate_positive_amount,
 )
 
 # Creation tests
@@ -138,5 +139,31 @@ def test_amount_validator_raises_on_too_large():
 
 def test_amount_validator_ok():
     result = validate_maximum_cash_amount(5000)
+    assert result.is_success is True
+    assert result.error_messages == []
+
+
+# validate_positive_amount tests
+
+def test_positive_amount_validator_with_negative_amount():
+    result = validate_positive_amount(-100)
+    assert result.is_success is False
+    assert "Amount must be positive." in result.error_messages
+
+
+def test_positive_amount_validator_with_zero():
+    result = validate_positive_amount(0)
+    assert result.is_success is False
+    assert "Amount must be positive." in result.error_messages
+
+
+def test_positive_amount_validator_with_positive_amount():
+    result = validate_positive_amount(100)
+    assert result.is_success is True
+    assert result.error_messages == []
+
+
+def test_positive_amount_validator_with_large_positive_amount():
+    result = validate_positive_amount(50000)
     assert result.is_success is True
     assert result.error_messages == []


### PR DESCRIPTION
## Popis problému
Transfer endpoint umožňoval zadat negativní částky, což je bezpečnostní a logické selhání.

## Řešení
- Přidán validator `validate_positive_amount()` který ověřuje, že částka je kladné číslo
- Aplikována validace na `/bank/transfer` endpoint
- Přidány komprehensivní testy pro validaci kladné částky

## Změnené soubory
- `app/validator/amount_validator.py` - Přidán `validate_positive_amount()` validator
- `app/api/bank_routes.py` - Přidána validace v transfer endpoint
- `app/validator/test_amount_validator.py` - Přidány testy

## Testy
Všechny nové validace jsou pokryty testy:
- ✅ Negativní částka je odmítnuta
- ✅ Nula je odmítnuta  
- ✅ Kladné částky jsou povoleny
- ✅ Velké kladné částky jsou povoleny

## Typ změny
- 🐛 Bug fix